### PR TITLE
add config option to disable line wrapping so we don't garble ansi art on small screens

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,9 @@
 name: Lint for errors
 on:
   push:
-    branches: ['main']
+    branches: [main]
+  pull_request:
+    branches: [main]
 jobs:
   lint:
     name: Basic linting for syntax errors

--- a/README.md
+++ b/README.md
@@ -73,3 +73,8 @@ Art to be displayed is assumed to use the [Code Page 437]( https://en.wikipedia.
 ## License
 
 This project is licensed under the [ MIT ](./LICENSE) license
+
+### Special Thanks 🙇
+
+* To [romkatv](https://www.reddit.com/r/zsh/comments/12ueb6b/comment/jhmlgez/?utm_source=share&utm_medium=web2x&context=3) for posting a fix for the word wrapping issue on narrow terminals
+* To [mainsm](https://github.com/yuhonas/zsh-ansimotd/issues/5#issue-1683181011) for posting 👆 as an issue in the repo

--- a/zsh-ansimotd.plugin.zsh
+++ b/zsh-ansimotd.plugin.zsh
@@ -53,9 +53,16 @@ function ansi_art_random {
   ansi_filename="$(ansi_art_random_file)"
 
   if [ -n "$ansi_filename" ]; then
+    # turn off automatic margins (a.k.a. line wrapping) unless we've been told not to
+    # this so it'll still render something usable even if the terminal is too narrow
+    if [ -z "$ANSI_MOTD_DONT_DISABLE_LINE_WRAPPING" ]; then print -n '\e[?7l'; fi;
+
     # convert from the original character set (Code page 437)
     # see https://en.wikipedia.org/wiki/Code_page_437
     iconv -f 437 < $ansi_filename
+
+    # restore automatic margins unless we've been told not to
+    if [ -z "$ANSI_MOTD_DONT_DISABLE_LINE_WRAPPING" ]; then print -n '\e[?7h'; fi;
 
     # record the filename in this session incase the user wants to find it later
     export ANSI_MOTD_FILENAME="$ansi_filename"


### PR DESCRIPTION
Fixes https://github.com/yuhonas/zsh-ansimotd/issues/5 

### Demo of the issue

#### With sufficient terminal width $COLUMNS >= 80
<img width="633" alt="ansi-1" src="https://user-images.githubusercontent.com/4928/235011162-6da8c8ee-7faf-4dac-b129-7c7513ad640e.png">

#### Without sufficient terminal width 
<img width="453" alt="ansi-2" src="https://user-images.githubusercontent.com/4928/235011169-8fc15d0c-ef3c-4a54-aed4-60bcc345fe4b.png">

#### With the fix in place, the art is truncated at the screen width, not perfect but much more usable
<img width="459" alt="ansi-3" src="https://user-images.githubusercontent.com/4928/235011182-512662b1-e3da-4f2f-8aab-2ce908354fbb.png">
