### PR TITLE
Fix level argument for wget

### DIFF
--- a/zsh-ansimotd.plugin.zsh
+++ b/zsh-ansimotd.plugin.zsh
@@ -14,7 +14,7 @@ ANSI_ART_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/ansimotd"
 # eg. ansi_art_download "http://artscene.textfiles.com/artpacks/1996/"
 function ansi_art_download {
   wget --directory-prefix "$ANSI_ART_DIR" --recursive \
-       --no-verbose --no-clobber --no-parent --level= 1 --accept zip "$1"
+       --no-verbose --no-clobber --no-parent --level 1 --accept zip "$1"
 
   cd "$ANSI_ART_DIR"
 


### PR DESCRIPTION
Before this fix, wget would interpret 1 as the source URL, trying to connect to http://0.0.0.1/, eventually ending up in connection timeout.